### PR TITLE
fix: add empty dir volume if read only fs

### DIFF
--- a/charts/contentserver/Chart.yaml
+++ b/charts/contentserver/Chart.yaml
@@ -17,5 +17,5 @@ annotations:
     - name: Image Source
       url: https://github.com/foomo/contentserver
 
-version: 0.6.1
+version: 0.6.2
 appVersion: 1.12.0

--- a/charts/contentserver/README.md
+++ b/charts/contentserver/README.md
@@ -1,6 +1,6 @@
 # contentserver
 
-![Version: 0.6.1](https://img.shields.io/badge/Version-0.6.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.12.0](https://img.shields.io/badge/AppVersion-1.12.0-informational?style=flat-square)
+![Version: 0.6.2](https://img.shields.io/badge/Version-0.6.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.12.0](https://img.shields.io/badge/AppVersion-1.12.0-informational?style=flat-square)
 
 Helm chart for the foomo Content Server.
 

--- a/charts/contentserver/templates/statefulset.yaml
+++ b/charts/contentserver/templates/statefulset.yaml
@@ -94,7 +94,7 @@ spec:
           envFrom: {{- toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:
-          {{- if .Values.persistence.enabled }}
+          {{- if or (.Values.contentserver.securityContext.readOnlyRootFilesystem) (.Values.persistence.enabled) }}
           - name: storage
             mountPath: {{ .Values.persistence.path }}
           {{- end }}
@@ -152,6 +152,10 @@ spec:
       {{- end }}
       {{- end }}
       volumes:
+        {{- if and (.Values.contentserver.securityContext.readOnlyRootFilesystem) (not .Values.persistence.enabled) }}
+        - name: storage
+          emptyDir: {}
+        {{- end }}
         {{- if .Values.contentserver.securityContext.readOnlyRootFilesystem }}
         - name: tmp
           emptyDir: {}


### PR DESCRIPTION
### Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch

### Description
Add empty dir if read only FS and persistence is disabled

### Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
