### PR TITLE
feat(namespace): resources

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,5 +1,9 @@
 [tools]
-# https://github.com/helm/helm/releases
-helm = "4.2.0"
+# https://mise-tools.jdx.dev/tools/helm
+helm = "4.2.2"
+# https://mise-tools.jdx.dev/tools/helm-docs
+helm-docs = "1.14.2"
 # https://github.com/dadav/helm-schema/releases
-"github:dadav/helm-schema" = "0.23.3"
+"github:dadav/helm-schema" = "0.23.4"
+# https://github.com/helm/chart-releaser/releases
+"github:helm/chart-releaser" = "1.8.1"

--- a/Makefile
+++ b/Makefile
@@ -44,10 +44,11 @@ lint: schema
 
 .PHONY: docs
 ## Generate README (https://github.com/norwoodj/helm-docs)
+docs: root=$(shell pwd)
 docs:
 	@echo "--- docs ------------------------------------------"
-	@set -e; for dir in ./charts/* ; do \
-		docker run --rm --volume "$$(pwd)/$${dir}:/helm-docs/$${dir}" jnorwood/helm-docs:v1.14.2 --template-files "$${dir}/README.md.gotmpl"  ;\
+	@for dir in ./charts/* ; do \
+		( cd "$${dir}" && helm-docs --template-files "README.md.gotmpl" ); \
 	done
 
 # (https://github.com/knechtionscoding/helm-schema-gen)

--- a/charts/namespace/Chart.yaml
+++ b/charts/namespace/Chart.yaml
@@ -14,5 +14,5 @@ annotations:
     - name: Chart Source
       url: https://github.com/foomo/helm-charts/tree/main/charts/namespace
 
-version: 0.5.1
-appVersion: 0.5.1
+version: 0.6.0
+appVersion: 0.6.0

--- a/charts/namespace/README.md
+++ b/charts/namespace/README.md
@@ -1,6 +1,6 @@
 # namespace
 
-![Version: 0.5.1](https://img.shields.io/badge/Version-0.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.5.1](https://img.shields.io/badge/AppVersion-0.5.1-informational?style=flat-square)
+![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.6.0](https://img.shields.io/badge/AppVersion-0.6.0-informational?style=flat-square)
 
 Common Namespace Resource Chart
 
@@ -22,7 +22,9 @@ Common Namespace Resource Chart
 | disableSuffix | bool | `false` | Disable suffixes |
 | dockerSecrets | object | `{}` | Docker config json secrets |
 | externalSecrets | object | `{}` | External Secrets to create (requires external-secrets.io/v1 CRD) |
+| resources | object | `{}` | Service accounts settings |
 | roleBindings | object | `{}` | Role Bindings to create |
+| roles | object | `{}` | Roles to create |
 | secrets | object | `{}` | Opaque secrets |
 | serviceAccounts | object | `{}` | Service accounts settings |
 | tlsSecrets | object | `{}` | TLS secrets |

--- a/charts/namespace/examples/clusterrole.yaml
+++ b/charts/namespace/examples/clusterrole.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=./../values.schema.json
+clusterRoles:
+  my-cluster-role:
+    annotations: {}
+    labels: {}
+    rules: {}

--- a/charts/namespace/examples/clusterrolebindings.yaml
+++ b/charts/namespace/examples/clusterrolebindings.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=./../values.schema.json
+cluserRoleBindings:
+  my-role-binding:
+    annotations:
+      replicator.v1.mittwald.de/replicate-to: ".*"
+    group: ""
+    role: ""

--- a/charts/namespace/examples/clusterroles.yaml
+++ b/charts/namespace/examples/clusterroles.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=./../values.schema.json
 clusterRoles:
   k9s:
     rules:

--- a/charts/namespace/examples/clustersecretstores.yaml
+++ b/charts/namespace/examples/clustersecretstores.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=./../values.schema.json
+clusterSecretStores:
+  my-cluster-secret-store:
+    annotations: {}
+    labels: {}
+    controller: ""
+    conditions:
+      - namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: my-namespace
+      - namespaces:
+          - my-namespace
+    provider:
+      aws:
+        service: SecretsManager
+        region: eu-central-1
+        auth:
+          jwt:
+            serviceAccountRef:
+              name: my-service-account
+              namespace: my-namespace

--- a/charts/namespace/examples/externalsecrets.yaml
+++ b/charts/namespace/examples/externalsecrets.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=./../values.schema.json
+externalSecrets:
+  my-secret:
+    annotations: {}
+    labels: {}
+    refreshInterval: 1h
+    refreshPolicy: Periodic
+    secretStoreRef:
+      name: my-cluster-secret-store
+      kind: ClusterSecretStore
+    target:
+      name: my-k8s-secret   # defaults to the key name (my-secret)
+      creationPolicy: Owner
+      deletionPolicy: Retain
+      template:
+        type: Opaque
+        metadata:
+          annotations: {}
+          labels: {}
+        data:
+          my-key: "{{ .my-key | b64dec }}"
+    data:
+      - secretKey: my-key
+        remoteRef:
+          key: /path/to/secret
+          property: my-property
+    dataFrom:
+      - extract:
+          key: /path/to/secret

--- a/charts/namespace/examples/resources.yaml
+++ b/charts/namespace/examples/resources.yaml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=./../values.schema.json
+resources:
+  my-resource:
+    apiVersion: external-secrets.io/v1
+    kind: ExternalSecret
+    spec:
+      data:
+        - secretKey: my-secret
+          remoteRef:
+            key: secret-name
+            version: "unique-hex-id"

--- a/charts/namespace/examples/rolebindings.yaml
+++ b/charts/namespace/examples/rolebindings.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=./../values.schema.json
+roleBindings:
+  my-role-binding:
+    annotations:
+      replicator.v1.mittwald.de/replicate-to: ".*"
+    group: ""
+    role: ""

--- a/charts/namespace/examples/roles.yaml
+++ b/charts/namespace/examples/roles.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=./../values.schema.json
+roles:
+  my-role:
+    rules:
+      - apiGroups:
+          - ''
+        resources:
+          - secrets
+        verbs:
+          - get
+      - apiGroups:
+          - ''
+        resources:
+          - pods
+        verbs:
+          - patch
+          - delete
+          - get

--- a/charts/namespace/examples/secrets.yaml
+++ b/charts/namespace/examples/secrets.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=./../values.schema.json
+secrets:
+  my-secret:
+    annotations:
+      replicator.v1.mittwald.de/replicate-to: ".*"
+    data: {}
+
+tlsSecrets:
+  my-domain.com:
+    annotations:
+      replicator.v1.mittwald.de/replicate-to: ".*"
+    data:
+      tls.crt: ''
+      tls.key: ''
+
+dockerSecrets:
+  hub.docker.com:
+    annotations:
+      replicator.v1.mittwald.de/replicate-to: ".*"
+    data: '{...}'

--- a/charts/namespace/examples/serviceaccounts.yaml
+++ b/charts/namespace/examples/serviceaccounts.yaml
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=./../values.schema.json
+serviceAccounts:
+  my-service-account:
+    annotations: {}
+    labels: {}

--- a/charts/namespace/examples/volumeclaims.yaml
+++ b/charts/namespace/examples/volumeclaims.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=./../values.schema.json
+volumeClaims:
+  my-volume:
+    name: my-existing-volume
+    annotations: {}
+    storageClass: local-path
+    size: 1Gi

--- a/charts/namespace/templates/_helpers.tpl
+++ b/charts/namespace/templates/_helpers.tpl
@@ -31,6 +31,13 @@ Create chart name and version as used by the chart label.
 {{- end }}
 
 {{/*
+Create chart name, version and release revision as used by the chart label.
+*/}}
+{{- define "namespace.revision" }}
+{{- printf "%s-%s-%d" .Chart.Name .Chart.Version .Release.Revision | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+
+{{/*
 Common labels
 */}}
 {{- define "namespace.labels" -}}

--- a/charts/namespace/templates/clusterrolebinding.yaml
+++ b/charts/namespace/templates/clusterrolebinding.yaml
@@ -14,7 +14,7 @@ metadata:
   namespace: {{ include "namespace.namespace" $ }}
 subjects: {{- tpl (toYaml $value.subjects) $ | nindent 2 }}
 roleRef:
-  kind: {{ $value.kind }}
+  kind: {{ default "ClusterRole" $value.kind }}
   name: {{ $value.role }}
   apiGroup: rbac.authorization.k8s.io
 ---

--- a/charts/namespace/templates/resources.yaml
+++ b/charts/namespace/templates/resources.yaml
@@ -1,0 +1,5 @@
+{{- range $key, $value := .Values.resources }}
+# Resource: {{ $key }}
+{{ tpl $value $ }}
+---
+{{- end }}

--- a/charts/namespace/templates/role.yaml
+++ b/charts/namespace/templates/role.yaml
@@ -1,0 +1,16 @@
+{{- range $key, $value := .Values.roles }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $key }}
+  labels:
+    {{- include "namespace.labels" $ | nindent 4 }}
+    {{- with $value.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with $value.annotations }}
+  annotations: {{- toYaml . | nindent 4 }}
+  {{- end }}
+rules: {{- tpl (toYaml .rules) $ | nindent 2 }}
+---
+{{- end }}

--- a/charts/namespace/templates/rolebinding.yaml
+++ b/charts/namespace/templates/rolebinding.yaml
@@ -14,8 +14,8 @@ metadata:
   namespace: {{ include "namespace.namespace" $ }}
 subjects: {{- tpl (toYaml $value.subjects) $ | nindent 2 }}
 roleRef:
-  kind: {{ $value.kind }}
-  name: {{ $value.role }}
+  kind: {{ default "Role" $value.kind }}
+  name: {{ default $key $value.role }}
   apiGroup: rbac.authorization.k8s.io
 ---
 {{- end }}

--- a/charts/namespace/values.schema.json
+++ b/charts/namespace/values.schema.json
@@ -89,7 +89,7 @@
         },
         "type": "object"
       },
-      "description": "tlsSecrets:\n  my-domain.com:\n    annotations:\n      replicator.v1.mittwald.de/replicate-to: \".*\"\n    data:\n      tls.crt: ''\n      tls.key: ''\nDocker config json secrets",
+      "description": "Docker config json secrets",
       "required": [],
       "title": "dockerSecrets",
       "type": "object"
@@ -210,6 +210,16 @@
       "title": "namespaceOverride",
       "type": "string"
     },
+    "resources": {
+      "additionalProperties": {
+        "additionalProperties": true,
+        "type": "object"
+      },
+      "description": "Service accounts settings",
+      "required": [],
+      "title": "resources",
+      "type": "object"
+    },
     "roleBindings": {
       "additionalProperties": {
         "properties": {
@@ -218,6 +228,9 @@
             "type": "object"
           },
           "kind": {
+            "enum": [
+              "ClusterRole"
+            ],
             "type": "string"
           },
           "labels": {
@@ -228,14 +241,54 @@
             "type": "string"
           },
           "subjects": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
             "type": "array"
           }
         },
         "type": "object"
       },
-      "description": "clusterRoles:\n  my-cluster-role:\n    annotations: {}\n    labels: {}\n    rules: {}\nRole Bindings to create",
+      "description": "Role Bindings to create",
       "required": [],
       "title": "roleBindings",
+      "type": "object"
+    },
+    "roles": {
+      "additionalProperties": {
+        "properties": {
+          "annotations": {
+            "additionalProperties": true,
+            "type": "object"
+          },
+          "kind": {
+            "enum": [
+              "Role",
+              "ClusterRole"
+            ],
+            "type": "string"
+          },
+          "labels": {
+            "additionalProperties": true,
+            "type": "object"
+          },
+          "role": {
+            "type": "string"
+          },
+          "subjects": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "description": "Roles to create",
+      "required": [],
+      "title": "roles",
       "type": "object"
     },
     "secrets": {
@@ -294,7 +347,7 @@
         },
         "type": "object"
       },
-      "description": "secrets:\n  my-secret:\n    annotations:\n      replicator.v1.mittwald.de/replicate-to: \".*\"\n    data: {}\nTLS secrets",
+      "description": "TLS secrets",
       "required": [],
       "title": "tlsSecrets",
       "type": "object"

--- a/charts/namespace/values.yaml
+++ b/charts/namespace/values.yaml
@@ -27,16 +27,36 @@ disableSuffix: false
 
 # @schema
 # type: object
+# additionalProperties:
+#   type: object
+#   properties:
+#     labels:
+#       type: object
+#       additionalProperties: true
+#     annotations:
+#       type: object
+#       additionalProperties: true
+#     kind:
+#       type: string
+#       enum: [Role, ClusterRole]
+#     role:
+#       type: string
+#     subjects:
+#       type: array
+#       items:
+#         type: object
+#         additionalProperties: true
+# @schema
+# -- Roles to create
+# @section -- General
+roles: {}
+# @schema
+# type: object
 # additionalProperties: true
 # @schema
 # -- Cluster Roles to create
 # @section -- General
 clusterRoles: {}
-# clusterRoles:
-#   my-cluster-role:
-#     annotations: {}
-#     labels: {}
-#     rules: {}
 # @schema
 # type: object
 # additionalProperties:
@@ -48,12 +68,16 @@ clusterRoles: {}
 #     annotations:
 #       type: object
 #       additionalProperties: true
-#     subjects:
-#       type: array
 #     kind:
 #       type: string
+#       enum: [ClusterRole]
 #     role:
 #       type: string
+#     subjects:
+#       type: array
+#       items:
+#         type: object
+#         additionalProperties: true
 # @schema
 # -- Role Bindings to create
 # @section -- General
@@ -85,13 +109,6 @@ roleBindings: {}
 # -- Role Bindings to create
 # @section -- General
 clusterRoleBindings: {}
-# roleBindings:
-#   my-role-binding:
-#     annotations:
-#       replicator.v1.mittwald.de/replicate-to: ".*"
-#     group: ""
-#     role: ""
-
 
 # @schema
 # type: object
@@ -111,11 +128,6 @@ clusterRoleBindings: {}
 # -- Opaque secrets
 # @section -- General
 secrets: {}
-# secrets:
-#   my-secret:
-#     annotations:
-#       replicator.v1.mittwald.de/replicate-to: ".*"
-#     data: {}
 # @schema
 # type: object
 # additionalProperties:
@@ -131,13 +143,6 @@ secrets: {}
 # -- TLS secrets
 # @section -- General
 tlsSecrets: {}
-# tlsSecrets:
-#   my-domain.com:
-#     annotations:
-#       replicator.v1.mittwald.de/replicate-to: ".*"
-#     data:
-#       tls.crt: ''
-#       tls.key: ''
 # @schema
 # type: object
 # additionalProperties:
@@ -152,11 +157,6 @@ tlsSecrets: {}
 # -- Docker config json secrets
 # @section -- General
 dockerSecrets: {}
-# dockerSecrets:
-#   hub.docker.com:
-#     annotations:
-#       replicator.v1.mittwald.de/replicate-to: ".*"
-#     data: '{...}'
 
 # @schema
 # type: object
@@ -173,9 +173,6 @@ dockerSecrets: {}
 # -- Service accounts settings
 # @section -- General
 serviceAccounts: {}
-#  my-service-account:
-#    annotations: {}
-#    labels: {}
 
 # @schema
 # type: object
@@ -230,34 +227,6 @@ serviceAccounts: {}
 # -- External Secrets to create (requires external-secrets.io/v1 CRD)
 # @section -- General
 externalSecrets: {}
-# externalSecrets:
-#   my-secret:
-#     annotations: {}
-#     labels: {}
-#     refreshInterval: 1h
-#     refreshPolicy: Periodic
-#     secretStoreRef:
-#       name: my-cluster-secret-store
-#       kind: ClusterSecretStore
-#     target:
-#       name: my-k8s-secret   # defaults to the key name (my-secret)
-#       creationPolicy: Owner
-#       deletionPolicy: Retain
-#       template:
-#         type: Opaque
-#         metadata:
-#           annotations: {}
-#           labels: {}
-#         data:
-#           my-key: "{{ .my-key | b64dec }}"
-#     data:
-#       - secretKey: my-key
-#         remoteRef:
-#           key: /path/to/secret
-#           property: my-property
-#     dataFrom:
-#       - extract:
-#           key: /path/to/secret
 
 # @schema
 # type: object
@@ -284,26 +253,6 @@ externalSecrets: {}
 # -- Cluster Secret Stores to create (requires external-secrets.io/v1 CRD)
 # @section -- General
 clusterSecretStores: {}
-# clusterSecretStores:
-#   my-cluster-secret-store:
-#     annotations: {}
-#     labels: {}
-#     controller: ""
-#     conditions:
-#       - namespaceSelector:
-#           matchLabels:
-#             kubernetes.io/metadata.name: my-namespace
-#       - namespaces:
-#           - my-namespace
-#     provider:
-#       aws:
-#         service: SecretsManager
-#         region: eu-central-1
-#         auth:
-#           jwt:
-#             serviceAccountRef:
-#               name: my-service-account
-#               namespace: my-namespace
 
 # @schema
 # type: object
@@ -318,11 +267,14 @@ clusterSecretStores: {}
 # -- Service accounts settings
 # @section -- General
 volumeClaims: {}
-# volumeClaims:
-#   my-volume:
-#     name: my-existing-volume
-#     annotations: {}
-#     storageClass: local-path
-#     size: 1Gi
 
+# @schema
+# type: object
+# additionalProperties:
+#   type: object
+#   additionalProperties: true
+# @schema
+# -- Service accounts settings
+# @section -- General
+resources: {}
 

--- a/charts/squadron-cronjob/Chart.yaml
+++ b/charts/squadron-cronjob/Chart.yaml
@@ -14,5 +14,5 @@ annotations:
     - name: Chart Source
       url: https://github.com/foomo/helm-charts/tree/main/charts/squadron-cronjob
 
-version: 0.3.1
-appVersion: 0.3.1
+version: 0.3.2
+appVersion: 0.3.2

--- a/charts/squadron-cronjob/README.md
+++ b/charts/squadron-cronjob/README.md
@@ -1,6 +1,6 @@
 # squadron-cronjob
 
-![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.3.1](https://img.shields.io/badge/AppVersion-0.3.1-informational?style=flat-square)
+![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.3.2](https://img.shields.io/badge/AppVersion-0.3.2-informational?style=flat-square)
 
 Squadron CronJob Chart
 

--- a/charts/squadron-cronjob/templates/cronjob.yaml
+++ b/charts/squadron-cronjob/templates/cronjob.yaml
@@ -170,9 +170,9 @@ spec:
                 name: {{ include "squadron.cronjob.fullname" . }}
             {{- end }}
             {{- range $key, $value := .Values.secrets }}
-              - name: {{ include "squadron.cronjob.fullname" $ }}-{{ $key }}
-                secret:
-                  secretName: {{ include "squadron.cronjob.fullname" $ }}-{{ $key }}
+            - name: {{ include "squadron.cronjob.fullname" $ }}-{{ $key }}
+              secret:
+                secretName: {{ include "squadron.cronjob.fullname" $ }}-{{ $key }}
             {{- end }}
             {{- range .Values.secretMounts }}
             - name: {{ . }}

--- a/charts/squadron-cronjob/templates/secret.yaml
+++ b/charts/squadron-cronjob/templates/secret.yaml
@@ -19,7 +19,7 @@ metadata:
   namespace: {{ include "squadron.cronjob.namespace" $ }}
 type: Opaque
 {{- with $value.data }}
-data: {{ toYaml $value | nindent 2 }}
+data: {{ toYaml . | nindent 2 }}
 {{- end }}
 {{- with $value.stringData }}
 stringData: {{ toYaml . | nindent 2 }}

--- a/charts/squadron-keel-cronjob/Chart.yaml
+++ b/charts/squadron-keel-cronjob/Chart.yaml
@@ -15,5 +15,5 @@ annotations:
     - name: Chart Source
       url: https://github.com/foomo/helm-charts/tree/main/charts/squadron-keel-cronjob
 
-version: 0.7.2
-appVersion: 0.7.2
+version: 0.7.3
+appVersion: 0.7.3

--- a/charts/squadron-keel-cronjob/README.md
+++ b/charts/squadron-keel-cronjob/README.md
@@ -1,6 +1,6 @@
 # squadron-keel-cronjob
 
-![Version: 0.7.2](https://img.shields.io/badge/Version-0.7.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.2](https://img.shields.io/badge/AppVersion-0.7.2-informational?style=flat-square)
+![Version: 0.7.3](https://img.shields.io/badge/Version-0.7.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.3](https://img.shields.io/badge/AppVersion-0.7.3-informational?style=flat-square)
 
 Squadron Keel CronJob Chart
 

--- a/charts/squadron-keel-cronjob/templates/cronjob.yaml
+++ b/charts/squadron-keel-cronjob/templates/cronjob.yaml
@@ -170,14 +170,14 @@ spec:
                 claimName: {{ include "keel.cronjob.fullname" . }}-data
             {{- end }}
             {{- if .Values.configMap }}
-              - name: {{ include "keel.cronjob.fullname" . }}-config
-                configMap:
-                  name: {{ include "keel.cronjob.fullname" . }}
+            - name: {{ include "keel.cronjob.fullname" . }}-config
+              configMap:
+                name: {{ include "keel.cronjob.fullname" . }}
             {{- end }}
             {{- range $key, $value := .Values.secrets }}
-              - name: {{ include "keel.cronjob.fullname" $ }}-{{ $key }}
-                secret:
-                  secretName: {{ include "keel.cronjob.fullname" $ }}-{{ $key }}
+            - name: {{ include "keel.cronjob.fullname" $ }}-{{ $key }}
+              secret:
+                secretName: {{ include "keel.cronjob.fullname" $ }}-{{ $key }}
             {{- end }}
             {{- range .Values.secretMounts }}
             - name: {{ . }}

--- a/charts/squadron-keel-cronjob/templates/secret.yaml
+++ b/charts/squadron-keel-cronjob/templates/secret.yaml
@@ -19,7 +19,7 @@ metadata:
   namespace: {{ include "keel.cronjob.namespace" $ }}
 type: Opaque
 {{- with $value.data }}
-data: {{ toYaml $value | nindent 2 }}
+data: {{ toYaml . | nindent 2 }}
 {{- end }}
 {{- with $value.stringData }}
 stringData: {{ toYaml . | nindent 2 }}

--- a/charts/squadron-keel-server/Chart.yaml
+++ b/charts/squadron-keel-server/Chart.yaml
@@ -15,5 +15,5 @@ annotations:
     - name: Chart Source
       url: https://github.com/foomo/helm-charts/tree/main/charts/squadron-keel-server
 
-version: 0.11.0
-appVersion: 0.11.0
+version: 0.11.1
+appVersion: 0.11.1

--- a/charts/squadron-keel-server/README.md
+++ b/charts/squadron-keel-server/README.md
@@ -1,6 +1,6 @@
 # squadron-keel-server
 
-![Version: 0.11.0](https://img.shields.io/badge/Version-0.11.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.11.0](https://img.shields.io/badge/AppVersion-0.11.0-informational?style=flat-square)
+![Version: 0.11.1](https://img.shields.io/badge/Version-0.11.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.11.1](https://img.shields.io/badge/AppVersion-0.11.1-informational?style=flat-square)
 
 Squadron Keel Server Chart
 

--- a/charts/squadron-keel-server/templates/secret.yaml
+++ b/charts/squadron-keel-server/templates/secret.yaml
@@ -19,7 +19,7 @@ metadata:
   namespace: {{ include "keel.server.namespace" $ }}
 type: Opaque
 {{- with $value.data }}
-data: {{ toYaml $value | nindent 2 }}
+data: {{ toYaml . | nindent 2 }}
 {{- end }}
 {{- with $value.stringData }}
 stringData: {{ toYaml . | nindent 2 }}

--- a/charts/squadron-server/Chart.yaml
+++ b/charts/squadron-server/Chart.yaml
@@ -14,5 +14,5 @@ annotations:
     - name: Chart Source
       url: https://github.com/foomo/helm-charts/tree/main/charts/squadron-server
 
-version: 0.7.1
-appVersion: 0.7.1
+version: 0.7.2
+appVersion: 0.7.2

--- a/charts/squadron-server/README.md
+++ b/charts/squadron-server/README.md
@@ -1,6 +1,6 @@
 # squadron-server
 
-![Version: 0.7.1](https://img.shields.io/badge/Version-0.7.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.1](https://img.shields.io/badge/AppVersion-0.7.1-informational?style=flat-square)
+![Version: 0.7.2](https://img.shields.io/badge/Version-0.7.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.2](https://img.shields.io/badge/AppVersion-0.7.2-informational?style=flat-square)
 
 Squadron General Server Chart
 

--- a/charts/squadron-server/templates/deployment.yaml
+++ b/charts/squadron-server/templates/deployment.yaml
@@ -172,9 +172,9 @@ spec:
             claimName: {{ include "squadron.server.fullname" . }}-data
         {{- end }}
         {{- if .Values.configMap }}
-          - name: {{ include "squadron.server.fullname" . }}-config
-            configMap:
-              name: {{ include "squadron.server.fullname" . }}
+        - name: {{ include "squadron.server.fullname" . }}-config
+          configMap:
+            name: {{ include "squadron.server.fullname" . }}
         {{- end }}
         {{- range $key, $value := .Values.secrets }}
         - name: {{ include "squadron.server.fullname" $ }}-{{ $key }}

--- a/charts/squadron-server/templates/secret.yaml
+++ b/charts/squadron-server/templates/secret.yaml
@@ -19,7 +19,7 @@ metadata:
   namespace: {{ include "squadron.server.namespace" $ }}
 type: Opaque
 {{- with $value.data }}
-data: {{ toYaml $value | nindent 2 }}
+data: {{ toYaml . | nindent 2 }}
 {{- end }}
 {{- with $value.stringData }}
 stringData: {{ toYaml . | nindent 2 }}


### PR DESCRIPTION
### Description

Add RBAC roles and arbitrary resource support to the namespace chart, and fix a secret `data` templating bug across the squadron charts.

### Type of Change

- [x] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance
- [ ] ✅ Tests
- [ ] 🔧 Build/CI

### Changes

- Add `roles` support to the namespace chart (`Role`/`ClusterRole`) with labels, annotations, and `tpl`-rendered rules
- Add `resources` support to the namespace chart for rendering arbitrary templated manifests
- Extend `roleBindings` schema (`kind` enum, structured `subjects`) and add examples for roles, rolebindings, clusterroles, clusterrolebindings, secrets, externalsecrets, clustersecretstores, serviceaccounts, and volumeclaims
- Fix secret `data` rendering: use `toYaml .` instead of `toYaml $value` so only the `data` map is emitted (squadron-server, squadron-cronjob, squadron-keel-cronjob, squadron-keel-server)
- Clean up `values.schema.json` descriptions and refresh `values.yaml`
- Bump chart versions and dependencies

### Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
