### PR TITLE
fix: quote checksums

### DIFF
--- a/charts/squadron-cronjob/Chart.yaml
+++ b/charts/squadron-cronjob/Chart.yaml
@@ -14,5 +14,5 @@ annotations:
     - name: Chart Source
       url: https://github.com/foomo/helm-charts/tree/main/charts/squadron-cronjob
 
-version: 0.3.2
-appVersion: 0.3.2
+version: 0.3.3
+appVersion: 0.3.3

--- a/charts/squadron-cronjob/README.md
+++ b/charts/squadron-cronjob/README.md
@@ -1,6 +1,6 @@
 # squadron-cronjob
 
-![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.3.2](https://img.shields.io/badge/AppVersion-0.3.2-informational?style=flat-square)
+![Version: 0.3.3](https://img.shields.io/badge/Version-0.3.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.3.3](https://img.shields.io/badge/AppVersion-0.3.3-informational?style=flat-square)
 
 Squadron CronJob Chart
 

--- a/charts/squadron-cronjob/templates/cronjob.yaml
+++ b/charts/squadron-cronjob/templates/cronjob.yaml
@@ -12,7 +12,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
     {{- if .Values.configMap }}
-    checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum | trunc 7 }}
+    checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum | trunc 7 | quote }}
     {{- end }}
   namespace: {{ include "squadron.cronjob.namespace" . }}
 spec:

--- a/charts/squadron-keel-cronjob/Chart.yaml
+++ b/charts/squadron-keel-cronjob/Chart.yaml
@@ -15,5 +15,5 @@ annotations:
     - name: Chart Source
       url: https://github.com/foomo/helm-charts/tree/main/charts/squadron-keel-cronjob
 
-version: 0.7.3
-appVersion: 0.7.3
+version: 0.7.4
+appVersion: 0.7.4

--- a/charts/squadron-keel-cronjob/README.md
+++ b/charts/squadron-keel-cronjob/README.md
@@ -1,6 +1,6 @@
 # squadron-keel-cronjob
 
-![Version: 0.7.3](https://img.shields.io/badge/Version-0.7.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.3](https://img.shields.io/badge/AppVersion-0.7.3-informational?style=flat-square)
+![Version: 0.7.4](https://img.shields.io/badge/Version-0.7.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.4](https://img.shields.io/badge/AppVersion-0.7.4-informational?style=flat-square)
 
 Squadron Keel CronJob Chart
 

--- a/charts/squadron-keel-cronjob/templates/cronjob.yaml
+++ b/charts/squadron-keel-cronjob/templates/cronjob.yaml
@@ -12,7 +12,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
     {{- if .Values.configMap }}
-    checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum | trunc 7 }}
+    checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum | trunc 7 | quote }}
     {{- end }}
   namespace: {{ include "keel.cronjob.namespace" . }}
 spec:

--- a/charts/squadron-keel-server/Chart.yaml
+++ b/charts/squadron-keel-server/Chart.yaml
@@ -15,5 +15,5 @@ annotations:
     - name: Chart Source
       url: https://github.com/foomo/helm-charts/tree/main/charts/squadron-keel-server
 
-version: 0.11.1
-appVersion: 0.11.1
+version: 0.11.2
+appVersion: 0.11.2

--- a/charts/squadron-keel-server/README.md
+++ b/charts/squadron-keel-server/README.md
@@ -1,6 +1,6 @@
 # squadron-keel-server
 
-![Version: 0.11.1](https://img.shields.io/badge/Version-0.11.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.11.1](https://img.shields.io/badge/AppVersion-0.11.1-informational?style=flat-square)
+![Version: 0.11.2](https://img.shields.io/badge/Version-0.11.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.11.2](https://img.shields.io/badge/AppVersion-0.11.2-informational?style=flat-square)
 
 Squadron Keel Server Chart
 

--- a/charts/squadron-keel-server/templates/deployment.yaml
+++ b/charts/squadron-keel-server/templates/deployment.yaml
@@ -12,7 +12,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
     {{- if .Values.configMap }}
-    checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum | trunc 7 }}
+    checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum | trunc 7 | quote }}
     {{- end }}
   namespace: {{ include "keel.server.namespace" . }}
 spec:

--- a/charts/squadron-nextjs-server/Chart.yaml
+++ b/charts/squadron-nextjs-server/Chart.yaml
@@ -14,5 +14,5 @@ annotations:
     - name: Chart Source
       url: https://github.com/foomo/helm-charts/tree/main/charts/squadron-nextjs-server
 
-version: 0.10.0
-appVersion: 0.10.0
+version: 0.10.1
+appVersion: 0.10.1

--- a/charts/squadron-nextjs-server/README.md
+++ b/charts/squadron-nextjs-server/README.md
@@ -1,6 +1,6 @@
 # squadron-nextjs-server
 
-![Version: 0.10.0](https://img.shields.io/badge/Version-0.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.10.0](https://img.shields.io/badge/AppVersion-0.10.0-informational?style=flat-square)
+![Version: 0.10.1](https://img.shields.io/badge/Version-0.10.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.10.1](https://img.shields.io/badge/AppVersion-0.10.1-informational?style=flat-square)
 
 Squadron NextJS Server Chart
 

--- a/charts/squadron-nextjs-server/templates/deployment.yaml
+++ b/charts/squadron-nextjs-server/templates/deployment.yaml
@@ -12,7 +12,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
     {{- if .Values.configMap }}
-    checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum | trunc 7 }}
+    checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum | trunc 7 | quote }}
     {{- end }}
   namespace: {{ include "nextjs.server.namespace" . }}
 spec:

--- a/charts/squadron-server/Chart.yaml
+++ b/charts/squadron-server/Chart.yaml
@@ -14,5 +14,5 @@ annotations:
     - name: Chart Source
       url: https://github.com/foomo/helm-charts/tree/main/charts/squadron-server
 
-version: 0.7.2
-appVersion: 0.7.2
+version: 0.7.3
+appVersion: 0.7.3

--- a/charts/squadron-server/README.md
+++ b/charts/squadron-server/README.md
@@ -1,6 +1,6 @@
 # squadron-server
 
-![Version: 0.7.2](https://img.shields.io/badge/Version-0.7.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.2](https://img.shields.io/badge/AppVersion-0.7.2-informational?style=flat-square)
+![Version: 0.7.3](https://img.shields.io/badge/Version-0.7.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.3](https://img.shields.io/badge/AppVersion-0.7.3-informational?style=flat-square)
 
 Squadron General Server Chart
 

--- a/charts/squadron-server/templates/deployment.yaml
+++ b/charts/squadron-server/templates/deployment.yaml
@@ -12,7 +12,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
     {{- if .Values.configMap }}
-    checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum | trunc 7 }}
+    checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum | trunc 7 | quote }}
     {{- end }}
   namespace: {{ include "squadron.server.namespace" . }}
 spec:


### PR DESCRIPTION
### Description

Quote the `checksum/configmap` annotation value so Helm always renders it as a string.

### Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance
- [ ] ✅ Tests
- [ ] 🔧 Build/CI

### Changes

- Pipe the `sha256sum | trunc 7` checksum annotation through `| quote` in the pod template metadata, preventing YAML from coercing an all-digit or otherwise ambiguous 7-char hash into a non-string value.
- Applied across all five affected charts: `squadron-cronjob`, `squadron-keel-cronjob`, `squadron-keel-server`, `squadron-nextjs-server`, and `squadron-server`.
- Bumped each chart's `version`/`appVersion` and regenerated its `README.md`.

### Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
