### PR TITLE
fix(namespace): allow using strings or maps

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,27 +1,28 @@
 ### Description
 
-<!-- Required: One line summary of what the PR is about -->
+<!-- Required: One-line summary of what the PR is about -->
 
 ### Type of Change
 
-<!-- Check the relevant option, keep unselected ones. -->
+<!-- Required: Check the relevant option, keep unselected ones -->
 
 - [ ] 🐛 Bug fix
 - [ ] ✨ New feature
 - [ ] 💥 Breaking change
 - [ ] 📝 Documentation
 - [ ] ♻️ Refactoring
-- [ ] ⚡ Performance
+- [ ] 🏃‍➡️ Performance
 - [ ] ✅ Tests
+- [ ] 🔐 Security
 - [ ] 🔧 Build/CI
 
 ### Related Issues
 
-<!-- List of links to related issues: Fixes #123, Closes #456 -->
+<!-- Optional: List of links to related issues: Fixes #123, Closes #456 -->
 
 ### Changes
 
-<!-- List of one line key changes -->
+<!-- Optional: List of one-line key changes -->
 
 ### Checklist
 

--- a/charts/namespace/Chart.yaml
+++ b/charts/namespace/Chart.yaml
@@ -14,5 +14,5 @@ annotations:
     - name: Chart Source
       url: https://github.com/foomo/helm-charts/tree/main/charts/namespace
 
-version: 0.6.0
-appVersion: 0.6.0
+version: 0.6.1
+appVersion: 0.6.1

--- a/charts/namespace/README.md
+++ b/charts/namespace/README.md
@@ -1,6 +1,6 @@
 # namespace
 
-![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.6.0](https://img.shields.io/badge/AppVersion-0.6.0-informational?style=flat-square)
+![Version: 0.6.1](https://img.shields.io/badge/Version-0.6.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.6.1](https://img.shields.io/badge/AppVersion-0.6.1-informational?style=flat-square)
 
 Common Namespace Resource Chart
 

--- a/charts/namespace/templates/resources.yaml
+++ b/charts/namespace/templates/resources.yaml
@@ -1,5 +1,9 @@
 {{- range $key, $value := .Values.resources }}
 # Resource: {{ $key }}
+{{- if kindIs "string" $value }}
 {{ tpl $value $ }}
+{{- else }}
+{{ tpl (toYaml $value) $ }}
+{{- end }}
 ---
 {{- end }}


### PR DESCRIPTION
### Description

Allow `.Values.resources` entries to be either raw YAML strings or structured maps.

### Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] ♻️ Refactoring
- [ ] 🏃‍➡️ Performance
- [ ] ✅ Tests
- [ ] 🔐 Security
- [ ] 🔧 Build/CI

### Changes

- `templates/resources.yaml`: detect the entry kind — render string values via `tpl` directly, and convert map values with `toYaml` before templating
- Bump chart `version`/`appVersion` to `0.6.1` and refresh the README version badges

### Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.