### PR TITLE
fix(namespace): allow string or object

### DIFF
--- a/charts/namespace/Chart.yaml
+++ b/charts/namespace/Chart.yaml
@@ -14,5 +14,5 @@ annotations:
     - name: Chart Source
       url: https://github.com/foomo/helm-charts/tree/main/charts/namespace
 
-version: 0.6.1
-appVersion: 0.6.1
+version: 0.6.2
+appVersion: 0.6.2

--- a/charts/namespace/README.md
+++ b/charts/namespace/README.md
@@ -1,6 +1,6 @@
 # namespace
 
-![Version: 0.6.1](https://img.shields.io/badge/Version-0.6.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.6.1](https://img.shields.io/badge/AppVersion-0.6.1-informational?style=flat-square)
+![Version: 0.6.2](https://img.shields.io/badge/Version-0.6.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.6.2](https://img.shields.io/badge/AppVersion-0.6.2-informational?style=flat-square)
 
 Common Namespace Resource Chart
 

--- a/charts/namespace/examples/resources.yaml
+++ b/charts/namespace/examples/resources.yaml
@@ -9,3 +9,12 @@ resources:
           remoteRef:
             key: secret-name
             version: "unique-hex-id"
+  my-other-resource: |
+    apiVersion: external-secrets.io/v1
+    kind: ExternalSecret
+    spec:
+      data:
+        - secretKey: my-secret
+          remoteRef:
+            key: secret-name
+            version: "unique-hex-id"

--- a/charts/namespace/values.schema.json
+++ b/charts/namespace/values.schema.json
@@ -213,7 +213,10 @@
     "resources": {
       "additionalProperties": {
         "additionalProperties": true,
-        "type": "object"
+        "type": [
+          "object",
+          "string"
+        ]
       },
       "description": "Service accounts settings",
       "required": [],

--- a/charts/namespace/values.yaml
+++ b/charts/namespace/values.yaml
@@ -271,7 +271,7 @@ volumeClaims: {}
 # @schema
 # type: object
 # additionalProperties:
-#   type: object
+#   type: [object, string]
 #   additionalProperties: true
 # @schema
 # -- Service accounts settings


### PR DESCRIPTION
### Description

Allow `namespace` chart `resources` entries to be defined as either a YAML string or an object.

### Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] ♻️ Refactoring
- [ ] 🏃‍➡️ Performance
- [ ] ✅ Tests
- [ ] 🔐 Security
- [ ] 🔧 Build/CI

### Changes

- Relax `resources` schema to accept `[object, string]` in both `values.schema.json` and the `values.yaml` `@schema` annotation
- Add a string-based `ExternalSecret` example to `examples/resources.yaml`
- Bump chart `version`/`appVersion` to `0.6.2` and update README badges

### Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
