### PR TITLE
feat(contentserver): bump version & add extraobjects

### DIFF
--- a/charts/contentserver/Chart.yaml
+++ b/charts/contentserver/Chart.yaml
@@ -17,5 +17,5 @@ annotations:
     - name: Image Source
       url: https://github.com/foomo/contentserver
 
-version: 0.6.7
-appVersion: 1.20.0
+version: 0.7.0
+appVersion: 1.21.0

--- a/charts/contentserver/README.md
+++ b/charts/contentserver/README.md
@@ -1,6 +1,6 @@
 # contentserver
 
-![Version: 0.6.7](https://img.shields.io/badge/Version-0.6.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.20.0](https://img.shields.io/badge/AppVersion-1.20.0-informational?style=flat-square)
+![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.21.0](https://img.shields.io/badge/AppVersion-1.21.0-informational?style=flat-square)
 
 Helm chart for the foomo Content Server.
 
@@ -43,7 +43,7 @@ Helm chart for the foomo Content Server.
 | contentserver.hostAliases | list | `[]` | Host aliases |
 | contentserver.image.pullPolicy | string | `"IfNotPresent"` | Image tag |
 | contentserver.image.repository | string | `"foomo/contentserver"` | Image repository |
-| contentserver.image.tag | string | `"1.20.0"` | Image [tag](https://hub.docker.com/r/foomo/contentserver) |
+| contentserver.image.tag | string | `"1.21.0"` | Image [tag](https://hub.docker.com/r/foomo/contentserver) |
 | contentserver.imagePullSecrets | list | `[]` | Image pull secrets |
 | contentserver.livenessProbe | object | `{"httpGet":{"path":"/healthz/liveness","port":9400}}` | Liveness probe settings for pods |
 | contentserver.podAnnotations | object | `{}` | Annotations for pods |
@@ -207,3 +207,9 @@ Helm chart for the foomo Content Server.
 | serviceMonitor.relabelings | list | `[]` | ServiceMonitor relabel configs to apply to samples before scraping. |
 | serviceMonitor.scrapeTimeout | string | `""` | ServiceMonitor scrape timeout in Go duration format (e.g. 15s) |
 | serviceMonitor.targetLabels | list | `[]` | ServiceMonitor will add labels from the service to the Prometheus metric |
+
+### Other Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| extraObjects | object | `{}` |  |

--- a/charts/contentserver/templates/extraobjects.yaml
+++ b/charts/contentserver/templates/extraobjects.yaml
@@ -1,0 +1,9 @@
+{{ range $key, $value := .Values.extraObjects }}
+---
+# {{ $key }}
+{{- if typeIs "string" $value }}
+{{ tpl $value $ }}
+{{ else }}
+{{ tpl ($value | toYaml) $ }}
+{{- end }}
+{{ end }}

--- a/charts/contentserver/values.schema.json
+++ b/charts/contentserver/values.schema.json
@@ -194,7 +194,7 @@
               "type": "string"
             },
             "tag": {
-              "default": "1.20.0",
+              "default": "1.21.0",
               "description": "Image [tag](https://hub.docker.com/r/foomo/contentserver)",
               "title": "tag",
               "type": "string"
@@ -403,6 +403,13 @@
         "podAnnotations"
       ],
       "title": "contentserver",
+      "type": "object"
+    },
+    "extraObjects": {
+      "additionalProperties": true,
+      "description": "Utilized to add dynamic manifests via values",
+      "required": [],
+      "title": "extraObjects",
       "type": "object"
     },
     "fullnameOverride": {

--- a/charts/contentserver/values.yaml
+++ b/charts/contentserver/values.yaml
@@ -240,7 +240,7 @@ contentserver:
     # @schema
     # -- Image [tag](https://hub.docker.com/r/foomo/contentserver)
     # @section -- Content Server
-    tag: 1.20.0
+    tag: 1.21.0
   # @schema
   # type: object
   # additionalProperties: true
@@ -892,3 +892,10 @@ rbac:
   # -- Create PodSecurityPolicy
   # @section -- RBAC
   enabled: false
+
+# @schema
+# type: object
+# additionalProperties: true
+# @schema
+# Utilized to add dynamic manifests via values
+extraObjects: {}


### PR DESCRIPTION
### Description

Bump contentserver chart to appVersion 1.21.0 and add `extraObjects` support for injecting dynamic manifests via values.

### Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] ♻️ Refactoring
- [ ] 🏃‍➡️ Performance
- [ ] ✅ Tests
- [ ] 🔐 Security
- [ ] 🔧 Build/CI

### Changes

- Bump `appVersion` to `1.21.0` and chart `version` to `0.7.0`
- Add `extraObjects` value and `templates/extraobjects.yaml` to render dynamic manifests (supports both string and object entries via `tpl`)
- Add `extraObjects` to `values.schema.json` and document it in `README.md`

### Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
