### PR TITLE
feat: bump deps and add extraObjects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/foomo)](https://artifacthub.io/packages/search?repo=foomo)
 ![Build Status](https://img.shields.io/github/actions/workflow/status/foomo/helm-charts/test.yaml?branch=main&logo=github&label=Build%20Status)
+[![GitHub Stars](https://img.shields.io/github/stars/foomo/helm-charts.svg?style=flat-square&logo=github)](https://github.com/foomo/helm-charts)
 
 <p align="center">
   <img alt="foomo/squadron" src="docs/public/logo.png" width="400" height="400"/>

--- a/charts/backups/Chart.yaml
+++ b/charts/backups/Chart.yaml
@@ -14,5 +14,5 @@ annotations:
     - name: Chart Source
       url: https://github.com/foomo/helm-charts/main/charts/backups
 
-version: 0.2.2
-appVersion: 0.2.2
+version: 0.2.3
+appVersion: 0.2.3

--- a/charts/backups/README.md
+++ b/charts/backups/README.md
@@ -1,6 +1,6 @@
 # backups
 
-![Version: 0.2.2](https://img.shields.io/badge/Version-0.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2.2](https://img.shields.io/badge/AppVersion-0.2.2-informational?style=flat-square)
+![Version: 0.2.3](https://img.shields.io/badge/Version-0.2.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2.3](https://img.shields.io/badge/AppVersion-0.2.3-informational?style=flat-square)
 
 Helm chart for backing things up.
 
@@ -49,7 +49,7 @@ Helm chart for backing things up.
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | dump.mongodb.host | string | `""` | MongoDB host |
-| dump.mongodb.image | string | `"mongo:8.3.2"` | MongoDB image https://hub.docker.com/_/mongo |
+| dump.mongodb.image | string | `"mongo:8.3.8"` | MongoDB image https://hub.docker.com/_/mongo |
 | dump.mongodb.name | string | `"instance-name"` | MongoDB instance name |
 | dump.mongodb.password | string | `""` | MongoDB password |
 | dump.mongodb.port | string | `"27017"` | MongoDB port |
@@ -96,20 +96,20 @@ Helm chart for backing things up.
 |-----|------|---------|-------------|
 | upload.azure.clientId | string | `""` | Azure Client ID |
 | upload.azure.containerName | string | `""` | Container name |
-| upload.azure.image | string | `"mcr.microsoft.com/azure-cli:2.87.0"` | Upload image name https://learn.microsoft.com/en-us/cli/azure/release-notes-azure-cli?view=azure-cli-latest |
+| upload.azure.image | string | `"mcr.microsoft.com/azure-cli:2.89.1"` | Upload image name https://learn.microsoft.com/en-us/cli/azure/release-notes-azure-cli?view=azure-cli-latest |
 | upload.azure.prefix | string | `""` | Bucket prefix |
 | upload.azure.storageAccount | string | `""` | Storage Account name |
 | upload.azure.tenantId | string | `""` | Azure Tenant ID |
 | upload.azure.workloadIdentity.enabled | bool | `false` | Enable Azure Workload Identity |
 | upload.gcs.bucket | string | `""` | Bucket name |
-| upload.gcs.image | string | `"google/cloud-sdk:571.0.0"` | Upload image name https://hub.docker.com/r/google/cloud-sdk/tags |
+| upload.gcs.image | string | `"google/cloud-sdk:582.0.0"` | Upload image name https://hub.docker.com/r/google/cloud-sdk/tags |
 | upload.gcs.prefix | string | `""` | Bucket prefix |
 | upload.gcs.projectId | string | `""` | GCP Project ID |
 | upload.pullPolicy | string | `"IfNotPresent"` | Image tag |
 | upload.s3.accessKey | string | `""` | Bucket access key |
 | upload.s3.bucket | string | `""` | Bucket name |
 | upload.s3.endpoint | string | `""` | Bucket endpoint |
-| upload.s3.image | string | `"amazon/aws-cli:2.34.63"` | Upload image name https://hub.docker.com/r/amazon/aws-cli/tags |
+| upload.s3.image | string | `"amazon/aws-cli:2.36.32"` | Upload image name https://hub.docker.com/r/amazon/aws-cli/tags |
 | upload.s3.prefix | string | `""` | Bucket prefix |
 | upload.s3.region | string | `""` | Bucket region |
 | upload.s3.secretAccessKey | string | `""` | Bucket secret access key |

--- a/charts/backups/values.schema.json
+++ b/charts/backups/values.schema.json
@@ -149,7 +149,7 @@
               "type": "string"
             },
             "image": {
-              "default": "mongo:8.3.2",
+              "default": "mongo:8.3.8",
               "description": "MongoDB image\nhttps://hub.docker.com/_/mongo",
               "title": "image",
               "type": "string"
@@ -381,7 +381,7 @@
               "type": "string"
             },
             "image": {
-              "default": "mcr.microsoft.com/azure-cli:2.87.0",
+              "default": "mcr.microsoft.com/azure-cli:2.89.1",
               "description": "Upload image name\nhttps://learn.microsoft.com/en-us/cli/azure/release-notes-azure-cli?view=azure-cli-latest",
               "title": "image",
               "type": "string"
@@ -435,7 +435,7 @@
               "type": "string"
             },
             "image": {
-              "default": "google/cloud-sdk:571.0.0",
+              "default": "google/cloud-sdk:582.0.0",
               "description": "Upload image name\nhttps://hub.docker.com/r/google/cloud-sdk/tags",
               "title": "image",
               "type": "string"
@@ -490,7 +490,7 @@
               "type": "string"
             },
             "image": {
-              "default": "amazon/aws-cli:2.34.63",
+              "default": "amazon/aws-cli:2.36.32",
               "description": "Upload image name\nhttps://hub.docker.com/r/amazon/aws-cli/tags",
               "title": "image",
               "type": "string"

--- a/charts/backups/values.yaml
+++ b/charts/backups/values.yaml
@@ -122,7 +122,7 @@ upload:
     # -- Upload image name
     # https://hub.docker.com/r/amazon/aws-cli/tags
     # @section -- Upload
-    image: amazon/aws-cli:2.34.63
+    image: amazon/aws-cli:2.36.32
     # @schema
     # type: string
     # @schema
@@ -170,7 +170,7 @@ upload:
     # -- Upload image name
     # https://hub.docker.com/r/google/cloud-sdk/tags
     # @section -- Upload
-    image: google/cloud-sdk:571.0.0
+    image: google/cloud-sdk:582.0.0
     # @schema
     # type: string
     # @schema
@@ -200,7 +200,7 @@ upload:
     # -- Upload image name
     # https://learn.microsoft.com/en-us/cli/azure/release-notes-azure-cli?view=azure-cli-latest
     # @section -- Upload
-    image: mcr.microsoft.com/azure-cli:2.87.0
+    image: mcr.microsoft.com/azure-cli:2.89.1
     # @schema
     # type: string
     # @schema
@@ -244,7 +244,7 @@ upload:
       enabled: false
   # TODO do:
   # https://hub.docker.com/r/digitalocean/doctl
-  #  image: digitalocean/doctl:1.160.1
+  #  image: digitalocean/doctl:1.167.0
   #  bucket: bucket
   #  prefix: prefix
 
@@ -300,7 +300,7 @@ dump:
     # -- MongoDB image
     # https://hub.docker.com/_/mongo
     # @section -- MongoDB
-    image: mongo:8.3.2
+    image: mongo:8.3.8
     # @schema
     # type: string
     # @schema

--- a/charts/beam/Chart.yaml
+++ b/charts/beam/Chart.yaml
@@ -23,6 +23,6 @@ dependencies:
     version: 2.4.23
     repository: "oci://registry-1.docker.io/bitnamicharts"
     condition: pinniped.enabled
-version: 0.6.8
-appVersion: 0.6.8
+version: 0.6.9
+appVersion: 0.6.9
 

--- a/charts/beam/README.md
+++ b/charts/beam/README.md
@@ -1,6 +1,6 @@
 # beam
 
-![Version: 0.6.8](https://img.shields.io/badge/Version-0.6.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.6.8](https://img.shields.io/badge/AppVersion-0.6.8-informational?style=flat-square)
+![Version: 0.6.9](https://img.shields.io/badge/Version-0.6.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.6.9](https://img.shields.io/badge/AppVersion-0.6.9-informational?style=flat-square)
 
 Secure infrastructure access
 
@@ -136,7 +136,7 @@ HTTPS_PROXY=socks5://127.0.0.1:1234 kubectl get namespaces --kubeconfig "beam-ku
 | cloudflared.image.pullPolicy | string | `"IfNotPresent"` | Image tag |
 | cloudflared.image.pullSecrets | list | `[]` | Image pull secrets |
 | cloudflared.image.repository | string | `"cloudflare/cloudflared"` | Image repository |
-| cloudflared.image.tag | string | `"2026.5.2"` | Image tag |
+| cloudflared.image.tag | string | `"2026.8.2"` | Image tag |
 | cloudflared.ingress | list | `[]` | Define ingress rules for the tunnel ([read more](https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/configuration/configuration-file/ingress)) |
 | cloudflared.livenessProbe | object | `{"failureThreshold":1,"httpGet":{"path":"/ready","port":2000},"initialDelaySeconds":10,"periodSeconds":10}` | Liveness probe settings for pods. |
 | cloudflared.podAnnotations | object | `{}` | Annotations for pods |
@@ -181,7 +181,7 @@ HTTPS_PROXY=socks5://127.0.0.1:1234 kubectl get namespaces --kubeconfig "beam-ku
 | cloudflaredSplitter.extraVolumeMounts | list | `[]` | Volume mounts to add |
 | cloudflaredSplitter.image.pullPolicy | string | `"IfNotPresent"` | Image tag |
 | cloudflaredSplitter.image.repository | string | `"nginx"` | Image repository |
-| cloudflaredSplitter.image.tag | string | `"1.31.1"` | Image tag |
+| cloudflaredSplitter.image.tag | string | `"1.31.4"` | Image tag |
 | cloudflaredSplitter.livenessProbe | object | `{}` | Liveness probe settings for pods |
 | cloudflaredSplitter.readinessProbe | object | `{}` | Readiness probe settings for pods |
 | cloudflaredSplitter.resources | object | `{}` | Resource request & limits. |

--- a/charts/beam/values.schema.json
+++ b/charts/beam/values.schema.json
@@ -191,7 +191,7 @@
               "type": "string"
             },
             "tag": {
-              "default": "2026.5.2",
+              "default": "2026.8.2",
               "description": "Image tag",
               "title": "tag",
               "type": "string"
@@ -644,7 +644,7 @@
               "type": "string"
             },
             "tag": {
-              "default": "1.31.1",
+              "default": "1.31.4",
               "description": "Image tag",
               "title": "tag",
               "type": "string"

--- a/charts/beam/values.yaml
+++ b/charts/beam/values.yaml
@@ -124,7 +124,7 @@ cloudflared:
     # @schema
     # -- Image tag
     # @section -- Cloudflared settings
-    tag: '2026.5.2' # https://github.com/cloudflare/cloudflared/releases
+    tag: '2026.8.2' # https://github.com/cloudflare/cloudflared/releases
   # @schema
   # type: object
   # @schema
@@ -480,7 +480,7 @@ cloudflaredSplitter:
     # @schema
     # -- Image tag
     # @section -- Cloudflared Splitter settings
-    tag: '1.31.1' # https://github.com/nginx/nginx/releases
+    tag: '1.31.4' # https://github.com/nginx/nginx/releases
   # @schema
   # type: object
   # additionalProperties: true

--- a/charts/sesamy-gtm/Chart.yaml
+++ b/charts/sesamy-gtm/Chart.yaml
@@ -18,5 +18,5 @@ annotations:
       url: https://github.com/foomo/helm-charts/tree/main/charts/sesamy-gtm
     - name: GTM Changelog
       url: https://developers.google.com/tag-platform/tag-manager/server-side/release-notes
-version: 0.6.5
-appVersion: 4.3.0
+version: 0.6.6
+appVersion: 4.4.0

--- a/charts/sesamy-gtm/README.md
+++ b/charts/sesamy-gtm/README.md
@@ -1,6 +1,6 @@
 # sesamy-gtm
 
-![Version: 0.6.5](https://img.shields.io/badge/Version-0.6.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.3.0](https://img.shields.io/badge/AppVersion-4.3.0-informational?style=flat-square)
+![Version: 0.6.6](https://img.shields.io/badge/Version-0.6.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.4.0](https://img.shields.io/badge/AppVersion-4.4.0-informational?style=flat-square)
 
 Helm chart for the Sesamy GTM tagging & preview service.
 
@@ -90,7 +90,7 @@ Helm chart for the Sesamy GTM tagging & preview service.
 | gtm.googleCloudProject | Optional | `""` | Google Cloud project ID |
 | gtm.image.pullPolicy | string | `"IfNotPresent"` | Image tag |
 | gtm.image.repository | string | `"gcr.io/cloud-tagging-10302018/gtm-cloud-image"` | The image repository |
-| gtm.image.tag | string | `"4.3.0"` | The image tag of the [release](https://console.cloud.google.com/artifacts/docker/cloud-tagging-10302018/us/gcr.io/gtm-cloud-image?pli=1) |
+| gtm.image.tag | string | `"4.4.0"` | The image tag of the [release](https://console.cloud.google.com/artifacts/docker/cloud-tagging-10302018/us/gcr.io/gtm-cloud-image?pli=1) |
 
 ### Ingress
 
@@ -153,7 +153,7 @@ Helm chart for the Sesamy GTM tagging & preview service.
 | proxy.config | string | `"server {\n  listen              443 ssl;\n\n  ssl_certificate     /etc/nginx/ssl/tls.crt;\n  ssl_certificate_key /etc/nginx/ssl/tls.key;\n  ssl_session_cache   shared:SSL:10m;\n  ssl_session_timeout 1h;\n  ssl_buffer_size     8k;\n\n  location / {\n      proxy_pass         http://0.0.0.0:{{ .Values.tagging.service.port }};\n      proxy_set_header   Host $host;\n      proxy_set_header   X-Real-IP $remote_addr;\n      proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;\n      proxy_set_header   X-Forwarded-Host $server_name;\n      proxy_set_header   Upgrade $http_upgrade;\n      proxy_set_header   Connection 'upgrade';\n      proxy_cache_bypass $http_upgrade;\n  }\n}\n"` | Nginx SSL Reverse Proxy config |
 | proxy.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | proxy.image.repository | string | `"nginx"` | The image repository |
-| proxy.image.tag | string | `"1.31.1-alpine"` | The image [tag](https://hub.docker.com/_/nginx) |
+| proxy.image.tag | string | `"1.31.4-alpine"` | The image [tag](https://hub.docker.com/_/nginx) |
 | proxy.resources | object | `{}` | Resource request & limits |
 | proxy.securityContext.allowPrivilegeEscalation | bool | `false` | Controls whether a process can gain more privileges than its parent process |
 | proxy.securityContext.capabilities | object | `{}` | Grant certain privileges to a process without granting all the privileges of the root user |

--- a/charts/sesamy-gtm/values.schema.json
+++ b/charts/sesamy-gtm/values.schema.json
@@ -477,7 +477,7 @@
               "type": "string"
             },
             "tag": {
-              "default": "4.3.0",
+              "default": "4.4.0",
               "description": "The image tag of the [release](https://console.cloud.google.com/artifacts/docker/cloud-tagging-10302018/us/gcr.io/gtm-cloud-image?pli=1)",
               "title": "tag",
               "type": "string"
@@ -1206,7 +1206,7 @@
               "type": "string"
             },
             "tag": {
-              "default": "1.31.1-alpine",
+              "default": "1.31.4-alpine",
               "description": "The image [tag](https://hub.docker.com/_/nginx)",
               "title": "tag",
               "type": "string"

--- a/charts/sesamy-gtm/values.yaml
+++ b/charts/sesamy-gtm/values.yaml
@@ -108,7 +108,7 @@ gtm:
     # @schema
     # -- The image tag of the [release](https://console.cloud.google.com/artifacts/docker/cloud-tagging-10302018/us/gcr.io/gtm-cloud-image?pli=1)
     # @section -- Google Tag Manager
-    tag: "4.3.0"
+    tag: "4.4.0"
 
 # @schema
 # type: object
@@ -166,7 +166,7 @@ proxy:
     # @schema
     # -- The image [tag](https://hub.docker.com/_/nginx)
     # @section -- HTTPS Proxy
-    tag: '1.31.1-alpine'
+    tag: '1.31.4-alpine'
   # @schema
   # type: object
   # @schema

--- a/charts/sesamy-umami/Chart.yaml
+++ b/charts/sesamy-umami/Chart.yaml
@@ -15,5 +15,5 @@ annotations:
       url: https://github.com/foomo/helm-charts/tree/main/charts/sesamy-umami
     - name: Umami Source
       url: https://github.com/umami-software/umami
-version: 0.3.1
-appVersion: 3.1.0
+version: 0.3.2
+appVersion: 3.3.1

--- a/charts/sesamy-umami/README.md
+++ b/charts/sesamy-umami/README.md
@@ -1,6 +1,6 @@
 # sesamy-umami
 
-![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.1.0](https://img.shields.io/badge/AppVersion-3.1.0-informational?style=flat-square)
+![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.3.1](https://img.shields.io/badge/AppVersion-3.3.1-informational?style=flat-square)
 
 Helm chart for the Sesamy Umami integration.
 
@@ -47,7 +47,7 @@ Helm chart for the Sesamy Umami integration.
 | proxy.config | string | `"server {\n  listen              443 ssl;\n\n  ssl_certificate     /etc/nginx/ssl/tls.crt;\n  ssl_certificate_key /etc/nginx/ssl/tls.key;\n  ssl_session_cache   shared:SSL:10m;\n  ssl_session_timeout 1h;\n  ssl_buffer_size     8k;\n\n  location / {\n      proxy_pass         http://0.0.0.0:{{ .Values.umami.service.port }};\n      proxy_set_header   Host $host;\n      proxy_set_header   X-Real-IP $remote_addr;\n      proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;\n      proxy_set_header   X-Forwarded-Host $server_name;\n      proxy_set_header   Upgrade $http_upgrade;\n      proxy_set_header   Connection 'upgrade';\n      proxy_cache_bypass $http_upgrade;\n  }\n}\n"` | Nginx SSL Reverse Proxy config. |
 | proxy.image.pullPolicy | string | `"IfNotPresent"` | Image tag |
 | proxy.image.repository | string | `"nginx"` | Image repository |
-| proxy.image.tag | string | `"1.31.1-alpine"` | Image tag |
+| proxy.image.tag | string | `"1.31.4-alpine"` | Image tag |
 | proxy.resources | object | `{}` | Resource request & limits. |
 | proxy.tls.crt | string | `""` | Base64 encoded TLS cert |
 | proxy.tls.key | string | `""` | Base64 encoded TLS key |
@@ -137,7 +137,7 @@ Helm chart for the Sesamy Umami integration.
 | umami.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | umami.image.registry | string | `"ghcr.io"` | The image registry |
 | umami.image.repository | string | `"umami-software/umami"` | The image repository |
-| umami.image.tag | string | `"3.1.0"` | The image tag |
+| umami.image.tag | string | `"3.3.1"` | The image tag |
 | umami.imagePullSecrets | list | `[]` | Image pull secrets |
 | umami.livenessProbe | object | `{"httpGet":{"path":"/","port":"http"}}` | Liveness probe settings for pods. |
 | umami.maxUnavailable | string | `nil` | Pod Disruption Budget maxUnavailable |

--- a/charts/sesamy-umami/values.schema.json
+++ b/charts/sesamy-umami/values.schema.json
@@ -230,7 +230,7 @@
               "type": "string"
             },
             "tag": {
-              "default": "1.31.1-alpine",
+              "default": "1.31.4-alpine",
               "description": "Image tag",
               "title": "tag",
               "type": "string"
@@ -887,7 +887,7 @@
               "type": "string"
             },
             "tag": {
-              "default": "3.1.0",
+              "default": "3.3.1",
               "description": "The image tag",
               "title": "tag",
               "type": "string"

--- a/charts/sesamy-umami/values.yaml
+++ b/charts/sesamy-umami/values.yaml
@@ -73,7 +73,7 @@ proxy:
     # @schema
     # -- Image tag
     # @section -- Proxy
-    tag: '1.31.1-alpine' # https://github.com/nginx/nginx/releases
+    tag: '1.31.4-alpine' # https://github.com/nginx/nginx/releases
   # @schema
   # type: object
   # @schema
@@ -322,7 +322,7 @@ umami:
     # @schema
     # -- The image tag
     # @section -- Umami
-    tag: 3.1.0 # https://github.com/umami-software/umami/pkgs/container/umami
+    tag: 3.3.1 # https://github.com/umami-software/umami/pkgs/container/umami
   # @schema
   # type: integer
   # @schema

--- a/charts/squadron-cronjob/Chart.yaml
+++ b/charts/squadron-cronjob/Chart.yaml
@@ -14,5 +14,5 @@ annotations:
     - name: Chart Source
       url: https://github.com/foomo/helm-charts/tree/main/charts/squadron-cronjob
 
-version: 0.3.3
-appVersion: 0.3.3
+version: 0.4.0
+appVersion: 0.4.0

--- a/charts/squadron-cronjob/README.md
+++ b/charts/squadron-cronjob/README.md
@@ -1,6 +1,6 @@
 # squadron-cronjob
 
-![Version: 0.3.3](https://img.shields.io/badge/Version-0.3.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.3.3](https://img.shields.io/badge/AppVersion-0.3.3-informational?style=flat-square)
+![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.0](https://img.shields.io/badge/AppVersion-0.4.0-informational?style=flat-square)
 
 Squadron CronJob Chart
 
@@ -141,3 +141,9 @@ Squadron CronJob Chart
 | serviceAccount.automount | bool | `false` | Automatically mount a ServiceAccount's API credentials? |
 | serviceAccount.create | bool | `false` | Specifies whether a service account should be created |
 | serviceAccount.name | string | `""` | The name of the service account to use. |
+
+### Other Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| extraObjects | object | `{}` |  |

--- a/charts/squadron-cronjob/templates/extraobjects.yaml
+++ b/charts/squadron-cronjob/templates/extraobjects.yaml
@@ -1,0 +1,9 @@
+{{- range $key, $value := .Values.extraObjects }}
+# Resource: {{ $key }}
+{{- if kindIs "string" $value }}
+{{ tpl $value $ }}
+{{- else }}
+{{ tpl (toYaml $value) $ }}
+{{- end }}
+---
+{{- end }}

--- a/charts/squadron-cronjob/values.schema.json
+++ b/charts/squadron-cronjob/values.schema.json
@@ -300,6 +300,12 @@
       "title": "env",
       "type": "object"
     },
+    "extraObjects": {
+      "additionalProperties": false,
+      "required": [],
+      "title": "extraObjects",
+      "type": "object"
+    },
     "fullnameOverride": {
       "default": "",
       "description": "Overrides the chart's computed fullname",

--- a/charts/squadron-cronjob/values.yaml
+++ b/charts/squadron-cronjob/values.yaml
@@ -636,3 +636,9 @@ scheduling:
   # -- Tolerations for pod assignment
   # @section -- Scheduling
   topologySpreadConstraints: []
+
+# @schema
+# type: object
+# additionProperties: true
+# @schema
+extraObjects: {}

--- a/charts/squadron-keel-cronjob/Chart.yaml
+++ b/charts/squadron-keel-cronjob/Chart.yaml
@@ -15,5 +15,5 @@ annotations:
     - name: Chart Source
       url: https://github.com/foomo/helm-charts/tree/main/charts/squadron-keel-cronjob
 
-version: 0.7.4
-appVersion: 0.7.4
+version: 0.8.0
+appVersion: 0.8.0

--- a/charts/squadron-keel-cronjob/README.md
+++ b/charts/squadron-keel-cronjob/README.md
@@ -1,6 +1,6 @@
 # squadron-keel-cronjob
 
-![Version: 0.7.4](https://img.shields.io/badge/Version-0.7.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.4](https://img.shields.io/badge/AppVersion-0.7.4-informational?style=flat-square)
+![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.8.0](https://img.shields.io/badge/AppVersion-0.8.0-informational?style=flat-square)
 
 Squadron Keel CronJob Chart
 
@@ -178,3 +178,9 @@ Squadron Keel CronJob Chart
 | serviceAccount.automount | bool | `false` | Automatically mount a ServiceAccount's API credentials? |
 | serviceAccount.create | bool | `false` | Specifies whether a service account should be created |
 | serviceAccount.name | string | `""` | The name of the service account to use. |
+
+### Other Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| extraObjects | object | `{}` |  |

--- a/charts/squadron-keel-cronjob/templates/extraobjects.yaml
+++ b/charts/squadron-keel-cronjob/templates/extraobjects.yaml
@@ -1,0 +1,9 @@
+{{- range $key, $value := .Values.extraObjects }}
+# Resource: {{ $key }}
+{{- if kindIs "string" $value }}
+{{ tpl $value $ }}
+{{- else }}
+{{ tpl (toYaml $value) $ }}
+{{- end }}
+---
+{{- end }}

--- a/charts/squadron-keel-cronjob/values.schema.json
+++ b/charts/squadron-keel-cronjob/values.schema.json
@@ -291,6 +291,12 @@
       "title": "env",
       "type": "object"
     },
+    "extraObjects": {
+      "additionalProperties": false,
+      "required": [],
+      "title": "extraObjects",
+      "type": "object"
+    },
     "fullnameOverride": {
       "default": "",
       "description": "Overrides the chart's computed fullname",

--- a/charts/squadron-keel-cronjob/values.yaml
+++ b/charts/squadron-keel-cronjob/values.yaml
@@ -800,3 +800,9 @@ scheduling:
   # -- Tolerations for pod assignment
   # @section -- Scheduling
   topologySpreadConstraints: []
+
+# @schema
+# type: object
+# additionProperties: true
+# @schema
+extraObjects: {}

--- a/charts/squadron-keel-server/Chart.yaml
+++ b/charts/squadron-keel-server/Chart.yaml
@@ -15,5 +15,5 @@ annotations:
     - name: Chart Source
       url: https://github.com/foomo/helm-charts/tree/main/charts/squadron-keel-server
 
-version: 0.11.2
-appVersion: 0.11.2
+version: 0.12.0
+appVersion: 0.12.0

--- a/charts/squadron-keel-server/README.md
+++ b/charts/squadron-keel-server/README.md
@@ -1,6 +1,6 @@
 # squadron-keel-server
 
-![Version: 0.11.2](https://img.shields.io/badge/Version-0.11.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.11.2](https://img.shields.io/badge/AppVersion-0.11.2-informational?style=flat-square)
+![Version: 0.12.0](https://img.shields.io/badge/Version-0.12.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.12.0](https://img.shields.io/badge/AppVersion-0.12.0-informational?style=flat-square)
 
 Squadron Keel Server Chart
 
@@ -254,3 +254,9 @@ Squadron Keel Server Chart
 | serviceMonitor.relabelings | list | `[]` | ServiceMonitor relabel configs to apply to samples before scraping. |
 | serviceMonitor.scrapeTimeout | string | `""` | ServiceMonitor scrape timeout in Go duration format (e.g. 15s) |
 | serviceMonitor.targetLabels | list | `[]` | ServiceMonitor will add labels from the service to the Prometheus metric |
+
+### Other Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| extraObjects | object | `{}` |  |

--- a/charts/squadron-keel-server/templates/extraobjects.yaml
+++ b/charts/squadron-keel-server/templates/extraobjects.yaml
@@ -1,0 +1,9 @@
+{{- range $key, $value := .Values.extraObjects }}
+# Resource: {{ $key }}
+{{- if kindIs "string" $value }}
+{{ tpl $value $ }}
+{{- else }}
+{{ tpl (toYaml $value) $ }}
+{{- end }}
+---
+{{- end }}

--- a/charts/squadron-keel-server/values.schema.json
+++ b/charts/squadron-keel-server/values.schema.json
@@ -99,6 +99,12 @@
       "title": "env",
       "type": "object"
     },
+    "extraObjects": {
+      "additionalProperties": false,
+      "required": [],
+      "title": "extraObjects",
+      "type": "object"
+    },
     "fullnameOverride": {
       "default": "",
       "description": "Overrides the chart's computed fullname",

--- a/charts/squadron-keel-server/values.yaml
+++ b/charts/squadron-keel-server/values.yaml
@@ -1209,3 +1209,9 @@ rbac:
   # -- Indicates wether scheduling is enabled or not
   # @section -- RBAC settings
   enabled: false
+
+# @schema
+# type: object
+# additionProperties: true
+# @schema
+extraObjects: {}

--- a/charts/squadron-nextjs-server/Chart.yaml
+++ b/charts/squadron-nextjs-server/Chart.yaml
@@ -14,5 +14,5 @@ annotations:
     - name: Chart Source
       url: https://github.com/foomo/helm-charts/tree/main/charts/squadron-nextjs-server
 
-version: 0.10.1
-appVersion: 0.10.1
+version: 0.11.0
+appVersion: 0.11.0

--- a/charts/squadron-nextjs-server/README.md
+++ b/charts/squadron-nextjs-server/README.md
@@ -1,6 +1,6 @@
 # squadron-nextjs-server
 
-![Version: 0.10.1](https://img.shields.io/badge/Version-0.10.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.10.1](https://img.shields.io/badge/AppVersion-0.10.1-informational?style=flat-square)
+![Version: 0.11.0](https://img.shields.io/badge/Version-0.11.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.11.0](https://img.shields.io/badge/AppVersion-0.11.0-informational?style=flat-square)
 
 Squadron NextJS Server Chart
 
@@ -242,3 +242,9 @@ Squadron NextJS Server Chart
 | serviceMonitor.relabelings | list | `[]` | ServiceMonitor relabel configs to apply to samples before scraping. |
 | serviceMonitor.scrapeTimeout | string | `""` | ServiceMonitor scrape timeout in Go duration format (e.g. 15s) |
 | serviceMonitor.targetLabels | list | `[]` | ServiceMonitor will add labels from the service to the Prometheus metric |
+
+### Other Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| extraObjects | object | `{}` |  |

--- a/charts/squadron-nextjs-server/templates/extraobjects.yaml
+++ b/charts/squadron-nextjs-server/templates/extraobjects.yaml
@@ -1,0 +1,9 @@
+{{- range $key, $value := .Values.extraObjects }}
+# Resource: {{ $key }}
+{{- if kindIs "string" $value }}
+{{ tpl $value $ }}
+{{- else }}
+{{ tpl (toYaml $value) $ }}
+{{- end }}
+---
+{{- end }}

--- a/charts/squadron-nextjs-server/values.schema.json
+++ b/charts/squadron-nextjs-server/values.schema.json
@@ -99,6 +99,12 @@
       "title": "env",
       "type": "object"
     },
+    "extraObjects": {
+      "additionalProperties": false,
+      "required": [],
+      "title": "extraObjects",
+      "type": "object"
+    },
     "fullnameOverride": {
       "default": "",
       "description": "Overrides the chart's computed fullname",

--- a/charts/squadron-nextjs-server/values.yaml
+++ b/charts/squadron-nextjs-server/values.yaml
@@ -1114,3 +1114,9 @@ rbac:
   # -- Indicates wether scheduling is enabled or not
   # @section -- RBAC settings
   enabled: false
+
+# @schema
+# type: object
+# additionProperties: true
+# @schema
+extraObjects: {}

--- a/charts/squadron-server/Chart.yaml
+++ b/charts/squadron-server/Chart.yaml
@@ -14,5 +14,5 @@ annotations:
     - name: Chart Source
       url: https://github.com/foomo/helm-charts/tree/main/charts/squadron-server
 
-version: 0.7.3
-appVersion: 0.7.3
+version: 0.8.0
+appVersion: 0.8.0

--- a/charts/squadron-server/README.md
+++ b/charts/squadron-server/README.md
@@ -1,6 +1,6 @@
 # squadron-server
 
-![Version: 0.7.3](https://img.shields.io/badge/Version-0.7.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.3](https://img.shields.io/badge/AppVersion-0.7.3-informational?style=flat-square)
+![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.8.0](https://img.shields.io/badge/AppVersion-0.8.0-informational?style=flat-square)
 
 Squadron General Server Chart
 
@@ -196,3 +196,9 @@ Squadron General Server Chart
 | serviceMonitor.relabelings | list | `[]` | ServiceMonitor relabel configs to apply to samples before scraping. |
 | serviceMonitor.scrapeTimeout | string | `""` | ServiceMonitor scrape timeout in Go duration format (e.g. 15s) |
 | serviceMonitor.targetLabels | list | `[]` | ServiceMonitor will add labels from the service to the Prometheus metric |
+
+### Other Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| extraObjects | object | `{}` |  |

--- a/charts/squadron-server/templates/extraobjects.yaml
+++ b/charts/squadron-server/templates/extraobjects.yaml
@@ -1,0 +1,9 @@
+{{- range $key, $value := .Values.extraObjects }}
+# Resource: {{ $key }}
+{{- if kindIs "string" $value }}
+{{ tpl $value $ }}
+{{- else }}
+{{ tpl (toYaml $value) $ }}
+{{- end }}
+---
+{{- end }}

--- a/charts/squadron-server/values.schema.json
+++ b/charts/squadron-server/values.schema.json
@@ -115,6 +115,12 @@
       "title": "env",
       "type": "object"
     },
+    "extraObjects": {
+      "additionalProperties": false,
+      "required": [],
+      "title": "extraObjects",
+      "type": "object"
+    },
     "fullnameOverride": {
       "default": "",
       "description": "Overrides the chart's computed fullname",

--- a/charts/squadron-server/values.yaml
+++ b/charts/squadron-server/values.yaml
@@ -909,3 +909,9 @@ scheduling:
     - maxSkew: 1
       topologyKey: "topology.kubernetes.io/zone"
       whenUnsatisfiable: ScheduleAnyway
+
+# @schema
+# type: object
+# additionProperties: true
+# @schema
+extraObjects: {}


### PR DESCRIPTION
### Description

Add an `extraObjects` values hook to all squadron charts, bump pinned image/chart versions across charts, and add a GitHub Stars badge to the root README.

### Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [x] 📝 Documentation
- [ ] ♻️ Refactoring
- [ ] 🏃‍➡️ Performance
- [ ] ✅ Tests
- [ ] 🔐 Security
- [x] 🔧 Build/CI

### Changes

- Add `templates/extraobjects.yaml` to `squadron-server`, `squadron-cronjob`, `squadron-keel-server`, `squadron-keel-cronjob` and `squadron-nextjs-server`, rendering arbitrary user-supplied manifests via `tpl` (accepts both string and object values).
- Add `extraObjects: {}` to those charts' `values.yaml` with `@schema` annotations, plus the matching `values.schema.json` entries; minor version bump (e.g. `squadron-server` 0.7.3 → 0.8.0).
- `backups`: bump `aws-cli` 2.34.63 → 2.36.32, `cloud-sdk` 571.0.0 → 582.0.0, `azure-cli` 2.87.0 → 2.89.1, `mongo` 8.3.2 → 8.3.8, `doctl` 1.160.1 → 1.167.0 (commented example); chart 0.2.2 → 0.2.3.
- `beam`: bump `cloudflared` 2026.5.2 → 2026.8.2 and nginx 1.31.1 → 1.31.4; chart 0.6.8 → 0.6.9.
- `sesamy-gtm`: bump GTM app 4.3.0 → 4.4.0 and nginx proxy 1.31.1-alpine → 1.31.4-alpine; chart 0.6.5 → 0.6.6.
- `sesamy-umami`: image/chart version bump.
- Regenerate all chart READMEs (helm-docs) and add a GitHub Stars badge to the root `README.md`.

### Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
