### PR TITLE
fix: extra objects

### DIFF
--- a/charts/blank/templates/_helpers.tpl
+++ b/charts/blank/templates/_helpers.tpl
@@ -31,6 +31,13 @@ Create chart name and version as used by the chart label.
 {{- end }}
 
 {{/*
+Create chart name, version and release revision as used by the chart label.
+*/}}
+{{- define "blank.revision" }}
+{{- printf "%s-%s-%d" .Chart.Name .Chart.Version .Release.Revision | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+
+{{/*
 Common labels
 */}}
 {{- define "blank.labels" -}}

--- a/charts/namespace/Chart.yaml
+++ b/charts/namespace/Chart.yaml
@@ -14,5 +14,5 @@ annotations:
     - name: Chart Source
       url: https://github.com/foomo/helm-charts/tree/main/charts/namespace
 
-version: 0.6.2
-appVersion: 0.6.2
+version: 0.6.3
+appVersion: 0.6.3

--- a/charts/namespace/README.md
+++ b/charts/namespace/README.md
@@ -1,6 +1,6 @@
 # namespace
 
-![Version: 0.6.2](https://img.shields.io/badge/Version-0.6.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.6.2](https://img.shields.io/badge/AppVersion-0.6.2-informational?style=flat-square)
+![Version: 0.6.3](https://img.shields.io/badge/Version-0.6.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.6.3](https://img.shields.io/badge/AppVersion-0.6.3-informational?style=flat-square)
 
 Common Namespace Resource Chart
 
@@ -22,7 +22,7 @@ Common Namespace Resource Chart
 | disableSuffix | bool | `false` | Disable suffixes |
 | dockerSecrets | object | `{}` | Docker config json secrets |
 | externalSecrets | object | `{}` | External Secrets to create (requires external-secrets.io/v1 CRD) |
-| resources | object | `{}` | Service accounts settings |
+| resources | object | `{}` | Extra k8s manifests to deploy |
 | roleBindings | object | `{}` | Role Bindings to create |
 | roles | object | `{}` | Roles to create |
 | secrets | object | `{}` | Opaque secrets |

--- a/charts/namespace/values.schema.json
+++ b/charts/namespace/values.schema.json
@@ -211,14 +211,8 @@
       "type": "string"
     },
     "resources": {
-      "additionalProperties": {
-        "additionalProperties": true,
-        "type": [
-          "object",
-          "string"
-        ]
-      },
-      "description": "Service accounts settings",
+      "additionalProperties": true,
+      "description": "Extra k8s manifests to deploy",
       "required": [],
       "title": "resources",
       "type": "object"

--- a/charts/namespace/values.yaml
+++ b/charts/namespace/values.yaml
@@ -270,11 +270,9 @@ volumeClaims: {}
 
 # @schema
 # type: object
-# additionalProperties:
-#   type: [object, string]
-#   additionalProperties: true
+# additionalProperties: true
 # @schema
-# -- Service accounts settings
+# -- Extra k8s manifests to deploy
 # @section -- General
 resources: {}
 

--- a/charts/squadron-cronjob/Chart.yaml
+++ b/charts/squadron-cronjob/Chart.yaml
@@ -14,5 +14,5 @@ annotations:
     - name: Chart Source
       url: https://github.com/foomo/helm-charts/tree/main/charts/squadron-cronjob
 
-version: 0.4.0
-appVersion: 0.4.0
+version: 0.4.1
+appVersion: 0.4.1

--- a/charts/squadron-cronjob/README.md
+++ b/charts/squadron-cronjob/README.md
@@ -1,6 +1,6 @@
 # squadron-cronjob
 
-![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.0](https://img.shields.io/badge/AppVersion-0.4.0-informational?style=flat-square)
+![Version: 0.4.1](https://img.shields.io/badge/Version-0.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.1](https://img.shields.io/badge/AppVersion-0.4.1-informational?style=flat-square)
 
 Squadron CronJob Chart
 
@@ -20,6 +20,7 @@ Squadron CronJob Chart
 | command | list | `[]` | Container command |
 | configMap | object | `{}` | Config map to be mounted |
 | env | object | `{}` | Map of environment variables to add |
+| extraObjects | object | `{}` | Extra k8s manifests to deploy |
 | revisionHistoryLimit | int | `10` | Number of revisions to keep |
 | schedule | string | `""` | Cron job schedule |
 | secretEnv | object | `{}` | Map of environment variables to add as a secret |
@@ -141,9 +142,3 @@ Squadron CronJob Chart
 | serviceAccount.automount | bool | `false` | Automatically mount a ServiceAccount's API credentials? |
 | serviceAccount.create | bool | `false` | Specifies whether a service account should be created |
 | serviceAccount.name | string | `""` | The name of the service account to use. |
-
-### Other Values
-
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| extraObjects | object | `{}` |  |

--- a/charts/squadron-cronjob/values.schema.json
+++ b/charts/squadron-cronjob/values.schema.json
@@ -301,7 +301,8 @@
       "type": "object"
     },
     "extraObjects": {
-      "additionalProperties": false,
+      "additionalProperties": true,
+      "description": "Extra k8s manifests to deploy",
       "required": [],
       "title": "extraObjects",
       "type": "object"

--- a/charts/squadron-cronjob/values.yaml
+++ b/charts/squadron-cronjob/values.yaml
@@ -639,6 +639,8 @@ scheduling:
 
 # @schema
 # type: object
-# additionProperties: true
+# additionalProperties: true
 # @schema
+# -- Extra k8s manifests to deploy
+# @section -- General
 extraObjects: {}

--- a/charts/squadron-keel-cronjob/Chart.yaml
+++ b/charts/squadron-keel-cronjob/Chart.yaml
@@ -15,5 +15,5 @@ annotations:
     - name: Chart Source
       url: https://github.com/foomo/helm-charts/tree/main/charts/squadron-keel-cronjob
 
-version: 0.8.0
-appVersion: 0.8.0
+version: 0.8.1
+appVersion: 0.8.1

--- a/charts/squadron-keel-cronjob/README.md
+++ b/charts/squadron-keel-cronjob/README.md
@@ -1,6 +1,6 @@
 # squadron-keel-cronjob
 
-![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.8.0](https://img.shields.io/badge/AppVersion-0.8.0-informational?style=flat-square)
+![Version: 0.8.1](https://img.shields.io/badge/Version-0.8.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.8.1](https://img.shields.io/badge/AppVersion-0.8.1-informational?style=flat-square)
 
 Squadron Keel CronJob Chart
 
@@ -18,6 +18,7 @@ Squadron Keel CronJob Chart
 |-----|------|---------|-------------|
 | configMap | object | `{}` | Config map to be mounted |
 | env | object | `{}` | Map of environment variables to add |
+| extraObjects | object | `{}` | Extra k8s manifests to deploy |
 | revisionHistoryLimit | int | `10` | Number of revisions to keep |
 | schedule | string | `""` | Cron job schedule |
 | secretEnv | object | `{}` | Map of environment variables to add as a secret |
@@ -178,9 +179,3 @@ Squadron Keel CronJob Chart
 | serviceAccount.automount | bool | `false` | Automatically mount a ServiceAccount's API credentials? |
 | serviceAccount.create | bool | `false` | Specifies whether a service account should be created |
 | serviceAccount.name | string | `""` | The name of the service account to use. |
-
-### Other Values
-
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| extraObjects | object | `{}` |  |

--- a/charts/squadron-keel-cronjob/values.schema.json
+++ b/charts/squadron-keel-cronjob/values.schema.json
@@ -292,7 +292,8 @@
       "type": "object"
     },
     "extraObjects": {
-      "additionalProperties": false,
+      "additionalProperties": true,
+      "description": "Extra k8s manifests to deploy",
       "required": [],
       "title": "extraObjects",
       "type": "object"

--- a/charts/squadron-keel-cronjob/values.yaml
+++ b/charts/squadron-keel-cronjob/values.yaml
@@ -803,6 +803,8 @@ scheduling:
 
 # @schema
 # type: object
-# additionProperties: true
+# additionalProperties: true
 # @schema
+# -- Extra k8s manifests to deploy
+# @section -- General
 extraObjects: {}

--- a/charts/squadron-keel-server/Chart.yaml
+++ b/charts/squadron-keel-server/Chart.yaml
@@ -15,5 +15,5 @@ annotations:
     - name: Chart Source
       url: https://github.com/foomo/helm-charts/tree/main/charts/squadron-keel-server
 
-version: 0.12.0
-appVersion: 0.12.0
+version: 0.12.1
+appVersion: 0.12.1

--- a/charts/squadron-keel-server/README.md
+++ b/charts/squadron-keel-server/README.md
@@ -1,6 +1,6 @@
 # squadron-keel-server
 
-![Version: 0.12.0](https://img.shields.io/badge/Version-0.12.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.12.0](https://img.shields.io/badge/AppVersion-0.12.0-informational?style=flat-square)
+![Version: 0.12.1](https://img.shields.io/badge/Version-0.12.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.12.1](https://img.shields.io/badge/AppVersion-0.12.1-informational?style=flat-square)
 
 Squadron Keel Server Chart
 
@@ -32,6 +32,7 @@ Squadron Keel Server Chart
 |-----|------|---------|-------------|
 | configMap | object | `{}` | Config map to be mounted |
 | env | object | `{}` | Map of environment variables to add |
+| extraObjects | object | `{}` | Extra k8s manifests to deploy |
 | ports | object | `{}` | Map of ports to expose |
 | replicas | int | `1` | Number of replications |
 | revisionHistoryLimit | int | `10` | Number of revisions to keep |
@@ -254,9 +255,3 @@ Squadron Keel Server Chart
 | serviceMonitor.relabelings | list | `[]` | ServiceMonitor relabel configs to apply to samples before scraping. |
 | serviceMonitor.scrapeTimeout | string | `""` | ServiceMonitor scrape timeout in Go duration format (e.g. 15s) |
 | serviceMonitor.targetLabels | list | `[]` | ServiceMonitor will add labels from the service to the Prometheus metric |
-
-### Other Values
-
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| extraObjects | object | `{}` |  |

--- a/charts/squadron-keel-server/values.schema.json
+++ b/charts/squadron-keel-server/values.schema.json
@@ -100,7 +100,8 @@
       "type": "object"
     },
     "extraObjects": {
-      "additionalProperties": false,
+      "additionalProperties": true,
+      "description": "Extra k8s manifests to deploy",
       "required": [],
       "title": "extraObjects",
       "type": "object"
@@ -142,6 +143,7 @@
         "expose": {
           "description": "Expose settings",
           "items": {
+            "additionalProperties": true,
             "required": [],
             "type": "object"
           },

--- a/charts/squadron-keel-server/values.yaml
+++ b/charts/squadron-keel-server/values.yaml
@@ -1186,7 +1186,7 @@ gateway:
   # type: array
   # items:
   #   type: object
-  #   additionProperties: true
+  #   additionalProperties: true
   # @schema
   # -- Expose settings
   # @section -- Gateway
@@ -1212,6 +1212,8 @@ rbac:
 
 # @schema
 # type: object
-# additionProperties: true
+# additionalProperties: true
 # @schema
+# -- Extra k8s manifests to deploy
+# @section -- General
 extraObjects: {}

--- a/charts/squadron-nextjs-server/Chart.yaml
+++ b/charts/squadron-nextjs-server/Chart.yaml
@@ -14,5 +14,5 @@ annotations:
     - name: Chart Source
       url: https://github.com/foomo/helm-charts/tree/main/charts/squadron-nextjs-server
 
-version: 0.11.0
-appVersion: 0.11.0
+version: 0.11.1
+appVersion: 0.11.1

--- a/charts/squadron-nextjs-server/README.md
+++ b/charts/squadron-nextjs-server/README.md
@@ -1,6 +1,6 @@
 # squadron-nextjs-server
 
-![Version: 0.11.0](https://img.shields.io/badge/Version-0.11.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.11.0](https://img.shields.io/badge/AppVersion-0.11.0-informational?style=flat-square)
+![Version: 0.11.1](https://img.shields.io/badge/Version-0.11.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.11.1](https://img.shields.io/badge/AppVersion-0.11.1-informational?style=flat-square)
 
 Squadron NextJS Server Chart
 
@@ -32,6 +32,7 @@ Squadron NextJS Server Chart
 |-----|------|---------|-------------|
 | configMap | object | `{}` | Config map to be mounted |
 | env | object | `{}` | Map of environment variables to add |
+| extraObjects | object | `{}` | Extra k8s manifests to deploy |
 | replicas | int | `1` | Number of replications |
 | revisionHistoryLimit | int | `10` | Number of revisions to keep |
 | secretEnv | object | `{}` | Map of environment variables to add as a secret |
@@ -242,9 +243,3 @@ Squadron NextJS Server Chart
 | serviceMonitor.relabelings | list | `[]` | ServiceMonitor relabel configs to apply to samples before scraping. |
 | serviceMonitor.scrapeTimeout | string | `""` | ServiceMonitor scrape timeout in Go duration format (e.g. 15s) |
 | serviceMonitor.targetLabels | list | `[]` | ServiceMonitor will add labels from the service to the Prometheus metric |
-
-### Other Values
-
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| extraObjects | object | `{}` |  |

--- a/charts/squadron-nextjs-server/values.schema.json
+++ b/charts/squadron-nextjs-server/values.schema.json
@@ -100,7 +100,8 @@
       "type": "object"
     },
     "extraObjects": {
-      "additionalProperties": false,
+      "additionalProperties": true,
+      "description": "Extra k8s manifests to deploy",
       "required": [],
       "title": "extraObjects",
       "type": "object"
@@ -142,6 +143,7 @@
         "expose": {
           "description": "Expose settings",
           "items": {
+            "additionalProperties": true,
             "required": [],
             "type": "object"
           },

--- a/charts/squadron-nextjs-server/values.yaml
+++ b/charts/squadron-nextjs-server/values.yaml
@@ -1091,7 +1091,7 @@ gateway:
   # type: array
   # items:
   #   type: object
-  #   additionProperties: true
+  #   additionalProperties: true
   # @schema
   # -- Expose settings
   # @section -- Gateway
@@ -1117,6 +1117,8 @@ rbac:
 
 # @schema
 # type: object
-# additionProperties: true
+# additionalProperties: true
 # @schema
+# -- Extra k8s manifests to deploy
+# @section -- General
 extraObjects: {}

--- a/charts/squadron-server/README.md
+++ b/charts/squadron-server/README.md
@@ -20,6 +20,7 @@ Squadron General Server Chart
 | command | list | `[]` | Container command |
 | configMap | object | `{}` | Config map to be mounted |
 | env | object | `{}` | Map of environment variables to add |
+| extraObjects | object | `{}` | Extra k8s manifests to deploy |
 | ports | object | `{}` | Map of ports to expose |
 | replicas | int | `1` | Number of replications |
 | revisionHistoryLimit | int | `10` | Number of revisions to keep |
@@ -196,9 +197,3 @@ Squadron General Server Chart
 | serviceMonitor.relabelings | list | `[]` | ServiceMonitor relabel configs to apply to samples before scraping. |
 | serviceMonitor.scrapeTimeout | string | `""` | ServiceMonitor scrape timeout in Go duration format (e.g. 15s) |
 | serviceMonitor.targetLabels | list | `[]` | ServiceMonitor will add labels from the service to the Prometheus metric |
-
-### Other Values
-
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| extraObjects | object | `{}` |  |

--- a/charts/squadron-server/values.schema.json
+++ b/charts/squadron-server/values.schema.json
@@ -116,7 +116,8 @@
       "type": "object"
     },
     "extraObjects": {
-      "additionalProperties": false,
+      "additionalProperties": true,
+      "description": "Extra k8s manifests to deploy",
       "required": [],
       "title": "extraObjects",
       "type": "object"

--- a/charts/squadron-server/values.yaml
+++ b/charts/squadron-server/values.yaml
@@ -912,6 +912,8 @@ scheduling:
 
 # @schema
 # type: object
-# additionProperties: true
+# additionalProperties: true
 # @schema
+# -- Extra k8s manifests to deploy
+# @section -- General
 extraObjects: {}


### PR DESCRIPTION
### Description

Fix `extraObjects` schema so arbitrary k8s manifests actually validate, and document the value across all charts.

### Type of Change

- [x] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [x] 📝 Documentation
- [ ] ♻️ Refactoring
- [ ] 🏃‍➡️ Performance
- [ ] ✅ Tests
- [ ] 🔐 Security
- [ ] 🔧 Build/CI

### Changes

- Fix `additionProperties` typo → `additionalProperties` in `extraObjects` and gateway `expose` schema annotations (squadron-server, squadron-cronjob, squadron-keel-*, squadron-nextjs-server)
- Change `extraObjects` JSON schema from `additionalProperties: false` to `true` so extra manifests are no longer rejected
- Document `extraObjects` as "Extra k8s manifests to deploy" and move it from "Other Values" into the General section
- Relax `namespace` chart `resources` schema to `additionalProperties: true` and correct its description (was "Service accounts settings")
- Add `blank.revision` helper emitting `<chart>-<version>-<revision>` for chart labels
- Bump patch versions: namespace 0.6.3, squadron-cronjob 0.4.1, squadron-keel-cronjob 0.8.1, squadron-keel-server 0.12.1, squadron-nextjs-server 0.11.1

### Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.